### PR TITLE
Fix `passing argument 1 of munmap from incompatible pointer type` gcc warning

### DIFF
--- a/src/atomic_ops.h
+++ b/src/atomic_ops.h
@@ -241,9 +241,10 @@ struct AO_uintptr_t_size_static_assert {
 # ifndef AO_MEMORY_SANITIZER
 #   define AO_ATTR_NO_SANITIZE_MEMORY /* empty */
 # elif AO_CLANG_PREREQ(3, 8)
-#   define AO_ATTR_NO_SANITIZE_MEMORY __attribute__((no_sanitize("memory")))
+#   define AO_ATTR_NO_SANITIZE_MEMORY \
+            __attribute__((__no_sanitize__("memory")))
 # else
-#   define AO_ATTR_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+#   define AO_ATTR_NO_SANITIZE_MEMORY __attribute__((__no_sanitize_memory__))
 # endif
 #endif /* !AO_ATTR_NO_SANITIZE_MEMORY */
 
@@ -251,9 +252,10 @@ struct AO_uintptr_t_size_static_assert {
 # ifndef AO_THREAD_SANITIZER
 #   define AO_ATTR_NO_SANITIZE_THREAD /* empty */
 # elif AO_CLANG_PREREQ(3, 8)
-#   define AO_ATTR_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
+#   define AO_ATTR_NO_SANITIZE_THREAD \
+            __attribute__((__no_sanitize__("thread")))
 # else
-#   define AO_ATTR_NO_SANITIZE_THREAD __attribute__((no_sanitize_thread))
+#   define AO_ATTR_NO_SANITIZE_THREAD __attribute__((__no_sanitize_thread__))
 # endif
 #endif /* !AO_ATTR_NO_SANITIZE_THREAD */
 

--- a/src/atomic_ops_malloc.c
+++ b/src/atomic_ops_malloc.c
@@ -209,7 +209,8 @@ AO_free_large(void *p)
 {
   size_t sz = (size_t)(((AO_uintptr_t *)p)[-1]);
 
-  if (munmap((AO_uintptr_t *)p - ALIGNMENT / sizeof(AO_uintptr_t), sz) != 0)
+  if (munmap((void *)((AO_uintptr_t *)p - ALIGNMENT / sizeof(AO_uintptr_t)),
+             sz) != 0)
     abort();  /* Programmer error.  Not really async-signal-safe, but ... */
 }
 


### PR DESCRIPTION
Also, add double-underscore prefix/suffix for no_sanitize attributes.