### PR TITLE
Fix LVAR_VOLATILE definition for cppcheck in test_atomic_include.template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -628,7 +628,7 @@ after_success:
     lcov --capture --directory src --directory tests --output-file coverage.info;
     lcov --remove coverage.info '/usr/*' 'tests/*' --output-file coverage.info;
     lcov --list coverage.info;
-    coveralls-lcov --repo-token ${COVERALLS_TOKEN} coverage.info;
+    coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} coverage.info;
   fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -616,7 +616,7 @@ script:
   fi
 - if [[ "$CPPCHECK_ENABLE" != "" ]]; then
     cppcheck -f --error-exitcode=2 -U AO_API -D CPPCHECK -I src
-             $CPPCHECK_ENABLE src/*.c tests/*.c;
+             $CPPCHECK_ENABLE --check-level=exhaustive src/*.c tests/*.c;
   fi
 - if [[ "$TESTS_CUSTOM_RUN" == true ]]; then
     ASAN_OPTIONS="detect_leaks=1" UBSAN_OPTIONS="halt_on_error=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - CC_FOR_CHECK=gcc
     - MAKEFILE_TARGET=all
     - REPORT_COVERAGE=true
-    - CFLAGS_EXTRA="-march=native -D DEBUG_RUN_ONE_TEST -D VERBOSE_STACK"
+    - CFLAGS_EXTRA="-fprofile-update=atomic -march=native -D DEBUG_RUN_ONE_TEST -D VERBOSE_STACK"
   - addons:
       apt:
         packages:

--- a/tests/test_atomic_include.h
+++ b/tests/test_atomic_include.h
@@ -45,7 +45,8 @@
   void double_list_atomic(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -658,7 +659,8 @@ void test_atomic(void)
   void double_list_atomic_release(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -1271,7 +1273,8 @@ void test_atomic_release(void)
   void double_list_atomic_acquire(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -1884,7 +1887,8 @@ void test_atomic_acquire(void)
   void double_list_atomic_read(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -2497,7 +2501,8 @@ void test_atomic_read(void)
   void double_list_atomic_write(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -3110,7 +3115,8 @@ void test_atomic_write(void)
   void double_list_atomic_full(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -3723,7 +3729,8 @@ void test_atomic_full(void)
   void double_list_atomic_release_write(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -4336,7 +4343,8 @@ void test_atomic_release_write(void)
   void double_list_atomic_acquire_read(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */
@@ -4949,7 +4957,8 @@ void test_atomic_acquire_read(void)
   void double_list_atomic_dd_acquire_read(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */

--- a/tests/test_atomic_include.template
+++ b/tests/test_atomic_include.template
@@ -45,7 +45,8 @@
   void double_list_atomicXX(void);
 #endif
 
-#ifdef LINT2
+#undef LVAR_VOLATILE
+#if defined(LINT2) && !defined(CPPCHECK)
   /* Workaround a warning that the argument of TA_assert() has a side   */
   /* effect because the variable is volatile.                           */
 # define LVAR_VOLATILE /* empty */


### PR DESCRIPTION
Fix of commit e8b241f97 (PR #79)