### PR TITLE
Fix lcov 'exclude pattern /usr/* is unused' error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -626,7 +626,7 @@ script:
 after_success:
 - if [[ "$REPORT_COVERAGE" == true ]]; then
     lcov --capture --directory src --directory tests --output-file coverage.info;
-    lcov --remove coverage.info '/usr/*' 'tests/*' --output-file coverage.info;
+    lcov --remove coverage.info 'tests/*' --output-file coverage.info;
     lcov --list coverage.info;
     coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} coverage.info;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -625,9 +625,9 @@ script:
 
 after_success:
 - if [[ "$REPORT_COVERAGE" == true ]]; then
-    lcov --capture --directory src --directory tests --output-file coverage.info;
-    lcov --remove coverage.info 'tests/*' --output-file coverage.info;
-    lcov --list coverage.info;
+    lcov --capture --directory src --directory tests --output-file coverage.info &&
+    lcov --remove coverage.info 'tests/*' --output-file coverage.info &&
+    lcov --list coverage.info &&
     coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} coverage.info;
   fi
 


### PR DESCRIPTION
Also, do not ignore lcov errors.