### PR TITLE
Fix missing branch info in Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -625,7 +625,7 @@ script:
 
 after_success:
 - if [[ "$REPORT_COVERAGE" == true ]]; then
-    lcov --capture --directory src --directory tests --output-file coverage.info &&
+    lcov --capture --directory src --directory tests --branch-coverage --output-file coverage.info &&
     lcov --remove coverage.info 'tests/*' --output-file coverage.info &&
     lcov --list coverage.info &&
     coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} --branch=${TRAVIS_BRANCH} coverage.info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -628,7 +628,7 @@ after_success:
     lcov --capture --directory src --directory tests --output-file coverage.info &&
     lcov --remove coverage.info 'tests/*' --output-file coverage.info &&
     lcov --list coverage.info &&
-    coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} coverage.info;
+    coveralls-lcov --repo-token=${COVERALLS_REPO_TOKEN} --branch=${TRAVIS_BRANCH} coverage.info;
   fi
 
 deploy:


### PR DESCRIPTION
Travis CI: Pass branch and verbose flags to coveralls-lcov
Travis CI: Turn on branch coverage in lcov